### PR TITLE
diaspy.models.Notification.when() use the create_at json field instea…

### DIFF
--- a/diaspy/models.py
+++ b/diaspy/models.py
@@ -195,7 +195,7 @@ class Notification():
     def when(self):
         """Returns UTC time as found in note_html.
         """
-        return self._when_regexp.search(self._data['note_html']).group(0)
+        return self._data['created_at']
 
     def mark(self, unread=False):
         """Marks notification to read/unread.


### PR DESCRIPTION
…d looking into the HTML code.

Patching what I told you at issue marekjm/diaspy#19

Using `created_at` json attribute is correct? Returns something like:

```
2015-05-23T09:07:21.000Z: A ***** y ***** les ha gustado tu Vuelto a compartir por ****.
```
