### PR TITLE
Fix dependency issue #42

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 diaspy
 requests==1.1.0
-dateutil>=2.2
+python-dateutil>=2.2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'Topic :: Utilities',
     ],
     packages=find_packages(),
-    install_requires=['requests', 'dateutil'],
+    install_requires=['requests', 'python-dateutil'],
     extras_require={
         'beautifulsoup4': ["beautifulsoup4>=3.2.1"]
     }

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'Topic :: Utilities',
     ],
     packages=find_packages(),
-    install_requires=['requests', 'dateutil']
+    install_requires=['requests', 'dateutil'],
     extras_require={
         'beautifulsoup4': ["beautifulsoup4>=3.2.1"]
     }


### PR DESCRIPTION
Fixes issue #42 (and apparently also fixes Issue #35 somehow)

Minor modifications to `setup.py` and `requirements.txt` were made to facilitate building `diaspy` under a Docker `python:3.6` image.  Mission accomplished.

My original intent was to investigate/resolve `diaspy` Issue #35 for enhancements to the [FeedSpora project](https://github.com/aurelg/feedspora), which uses `diaspy` functionality as a dependency.  The changes in this PR seem to have somehow fixed the image file upload issue in Issue #35; I found that no other changes in `diaspy` were needed to provide the functionality for FeedSpora's Diaspora client that I originally targeted.  Additional verification of this assertion by others is of course encouraged!